### PR TITLE
fixes event listeners stacking up when accessing menu

### DIFF
--- a/frontend/game/src/menu.ts
+++ b/frontend/game/src/menu.ts
@@ -10,36 +10,46 @@ import { Button } from './Button.js';
 
 export function startMenu(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) {
   let y = 200;
-  const space: number = 80;
+  const space = 80;
+
   const buttons: Button[] = [
     new Button(300, y, 200, 50, '1 Player', () => alert('1 player')),
-    new Button(300, y += space, 200, 50, '2 Players', () => launchGame()),
+    new Button(300, y += space, 200, 50, '2 Players', () => {
+      cleanup();
+      launchGame();
+    }),
     new Button(300, y += space, 200, 50, 'Tournament', () => alert('tournament')),
-    new Button(300, y += space, 200, 50, 'Quit', () => alert('quit')),
+    new Button(300, y += space, 200, 50, 'Quit', () => alert('Quit')),
   ];
 
-  drawMenu();
-
-  canvas.addEventListener('click', (e) => {
+  const handleClick = (e: MouseEvent) => {
     const rect = canvas.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
     buttons.forEach(button => {
       if (button.isClicked(x, y)) button.onClick();
     });
-  });
+  };
 
-  canvas.addEventListener('mousemove', (e) => {
-  const rect = canvas.getBoundingClientRect();
-  const mx = e.clientX - rect.left;
-  const my = e.clientY - rect.top;
+  const handleMouseMove = (e: MouseEvent) => {
+    const rect = canvas.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
 
-  buttons.forEach(button => {
-    button.hovered = button.isHovered(mx, my);
-  });
+    buttons.forEach(button => {
+      button.hovered = button.isHovered(mx, my);
+    });
 
-  drawMenu();
-});
+    drawMenu();
+  };
+
+  canvas.addEventListener('click', handleClick);
+  canvas.addEventListener('mousemove', handleMouseMove);
+
+  function cleanup() {
+    canvas.removeEventListener('click', handleClick);
+    canvas.removeEventListener('mousemove', handleMouseMove);
+  }
 
   function drawMenu() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -50,4 +60,6 @@ export function startMenu(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext
 
     buttons.forEach(button => button.draw(ctx));
   }
+
+  drawMenu();
 }

--- a/frontend/game/src/pong.ts
+++ b/frontend/game/src/pong.ts
@@ -62,7 +62,8 @@ export function startPong(canvas: HTMLCanvasElement, context: CanvasRenderingCon
   function resetBall() {
     ball.x = WIDTH / 2;
     ball.y = HEIGHT / 2;
-    ball.dx = -ball.dx;
+    const initialSpeed = 6;
+    ball.dx = Math.random() < 0.5 ? -initialSpeed : initialSpeed;
 
     // Avoid near-zero vertical angles
     let angle = 0;


### PR DESCRIPTION
Fixes previous issue of the game menu's event listeners (button clicks) stacking up every time the menu was revisited, resulting in multiple dialogs popping up when clicked. Also fixes the issue of the ball doubling its speed every time the game is restarted.