### PR TITLE
adds player put endpoint for updating either name or e-mail

### DIFF
--- a/backend/dataAccess/player.js
+++ b/backend/dataAccess/player.js
@@ -66,6 +66,20 @@ const findPlayerByName = async (name) => {
 	});
 };
 
+// Returns data for a single player when passing the player's e-mail
+const findPlayerByEMail = async (e_mail) => {
+	return prisma.player.findUnique({
+		where: { e_mail },
+		include: {
+			stats: {
+				include: {
+					matches: true,
+				},
+			},
+		}
+	});
+};
+
 // Function to delete a player by ID 
 // and deletes any matches where all players have been already deleted
 const deletePlayerById = async (id) => {
@@ -157,6 +171,19 @@ const updateAvatar = async (id, filePath) => {
 	})
 }
 
+// updates the player info (name or e-mail)
+const updatePlayerInfo = async (data) => {
+	const updateData = {};
+	if (data.name !== undefined) 
+		updateData.name = data.name;
+	if (data.e_mail !== undefined)
+		updateData.e_mail = data.e_mail;
+	return await prisma.player.update({
+		where: {id: data.id },
+		data: updateData,
+	});
+}
+
 module.exports = {
 	getAllPlayers,
 	createPlayer,
@@ -165,5 +192,7 @@ module.exports = {
 	addFriend,
 	deleteFriend,
 	deletePlayerById,
-	updateAvatar
+	updateAvatar,
+	findPlayerByEMail,
+	updatePlayerInfo
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -29,6 +29,8 @@ fastify.setErrorHandler((error, request, reply) => {
 			reply.status(400).send({ error: 'Invalid match data: resultPlayerOne, resultPlayerTwo and aiOpponent are required. Results need to be <= 10' });
 		else if (request.routerPath === '/api/players/:id/friends' && request.method === 'POST')
 			reply.status(400).send({ error: 'Invalid friend data: "name" required.' });
+		else if (request.routerPath === '/api/players/:id' && request.method === 'PUT')
+			reply.status(400).send({ error: 'Invalid player info data: "name" and/or "e-mail" required.' });
 		else
 			reply.status(400).send({ error: 'Invalid request data.' });
 	} 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -18,7 +18,7 @@ model Player {
   id       Int    @id @default(autoincrement())
   name     String @unique
   password String
-  e_mail   String?
+  e_mail   String? @unique
   online   Boolean?
   avatar   String?
   stats    Statistics @relation(fields: [statsId], references: [id], onDelete: Cascade) //establishes 1-1 relationship, deletes stats if player is deleted

--- a/backend/requests/available_apis.rest
+++ b/backend/requests/available_apis.rest
@@ -6,7 +6,7 @@
 GET http://localhost:3001/api/players
 
 ### Get single player
-GET http://localhost:3001/api/players/1
+GET http://localhost:3001/api/players/2
 
 ### Create player
 POST http://localhost:3001/api/players
@@ -15,6 +15,22 @@ Content-Type: application/json
 {
 	"name": "Player 3000",
 	"password": "30984308"
+}
+
+### Update player info (name only)
+PUT http://localhost:3001/api/players/1
+Content-Type: application/json
+
+{
+	"name": "Player 1"
+}
+
+### Update player info (e-mail only)
+PUT http://localhost:3001/api/players/1
+Content-Type: application/json
+
+{
+	"e_mail": "testmail@test.com"
 }
 
 ### Update player stats (ai match)

--- a/backend/schemas/player.js
+++ b/backend/schemas/player.js
@@ -48,4 +48,18 @@ const playerBodySchema = {
 	additionalProperties: false
 };
 
-module.exports = { playerBodySchema };
+// defines request schema for updating player's name and e-mail
+// only one of the properties is allowed per request, updating both at
+// the same time is not permitted
+const playerReqInfoSchema = {
+	type: 'object',
+	properties: {
+		name: { type: 'string'},
+		e_mail: { type: 'string'},
+	},
+	minProperties: 1,
+	maxProperties: 1,
+	additionalProperties: false
+}
+
+module.exports = { playerBodySchema, playerReqInfoSchema };


### PR DESCRIPTION
- now the backend also provides the route fastify.put('/api/players/:id'...) in order to update the player's name or e-mail
- field e-mail is now defined as unique in prisma schema (besides of name field), meaning duplicates regarding e-mail addresses are not allowed anymore

How to test:

delete the following dirs/files:
node_modules
dev.db file

compile:
make test_backend_server

go to file:
backend/requests/available_apis.rest
send GET for player 1 and check the name and e-mail:
GET http://localhost:3001/api/players/1

send request for PUT player 1 in order to change the name and another for changing the e-mail (4th and 5th testcase in the file):
PUT http://localhost:3001/api/players/1

The return is the player object with the updated fields. Changing player's name and e-mail to an already existing name/e-mail will throw an error (except it is the player's own name/e-mail).
Changing name and e-mail at the same time is not permitted and will throw an error.