### PR TITLE
extends the player object by adding friends' victories and defeats

### DIFF
--- a/backend/requests/available_apis.rest
+++ b/backend/requests/available_apis.rest
@@ -7,8 +7,8 @@ POST http://localhost:3001/api/login
 Content-Type: application/json
 
 {
-  "e_mail": "one@example.com",
-  "password": "23213"
+  "e_mail": "gugu@hauhau.com",
+  "password": "qwerty"
 }
 
 ### Send logout request for user

--- a/backend/schemas/player.js
+++ b/backend/schemas/player.js
@@ -43,8 +43,16 @@ const playerBodySchema = {
 					name: { type: 'string' },
 					avatar: { type: 'string'},
 					online: { type: 'boolean' },
+					stats: {
+						type: 'object',
+						properties: {
+							victories: { type: 'integer', minimum: 0, maximum: 1000 },
+							defeats: { type: 'integer', minimum: 0, maximum: 1000 }
+						},
+						additionalProperties: false
+					}
 				}
-			 }
+			}
 		},
 	},
 	additionalProperties: false


### PR DESCRIPTION
- calling the GET api/players/me endpoint now also provides the friend's victories/defeats stats (within the friends array of the player object)

how to test:
1. compile with make test_backend_w_ui
2. go to file ./backend/requests/available_apis.rest
3. send login request for user Gugu
4. send get api/players/me request
5. in the response screen of vs code is now the victories and defeats for each friend within the player object visible

alternatively go to the website, open dev tools menu and check network tab, the response for the me endpoint should now provide the fields mentioned above.

Context:
--> this adjustments were made in order to facilitate the update of the opponents statistics for the frontend, as the respective endpoint for updating the stats requires the opponent's name and his/her victories/defeats in case the match is a PvP match.