### PR TITLE
handles cases google sign-in users want to change their e-mail

### DIFF
--- a/backend/routes/playerRoutes.js
+++ b/backend/routes/playerRoutes.js
@@ -84,6 +84,11 @@ fastify.put('/api/players/me', putDivReqResSchema(playerReqInfoSchema, playerBod
 				return reply.status(404).send({ error: 'Name is not available anymore.' });
 		}
 		if (e_mail) {
+			// Prevent Google users from changing their email
+			if (player.auth === 'google' && e_mail !== player.e_mail) {
+				return reply.status(400).send({ error: 'Google users cannot change their email address.' });
+			}
+			
 			const foundPlayerByEMail = await Player.findPlayerByEMail(e_mail);
 			if (!foundPlayerByEMail || foundPlayerByEMail.id === player.id) {
 				const updatedPlayerInfo = await Player.updatePlayerInfo({

--- a/frontend/src/pages/MyEditPage.tsx
+++ b/frontend/src/pages/MyEditPage.tsx
@@ -115,7 +115,7 @@ export default function MyEditPage() {
 	} else if (message.includes('E-mail is not available')) {
 	alert('E-mail is not available anymore')
 	} else {
-	alert('Oh, something went wrong!!')
+	alert('Oh, something went wrong!! Altering e-mail when signed-in with Google not possible :(')
     }
   } finally {
     setLoading(false)


### PR DESCRIPTION
Scenario: A user is signed-in with Google and changes the e-mail address in the profile settings. After logging out and trying to login again with Google, only an error message is thrown in the browser console, no possibility of logging in for this user anymore.

Improvement: When trying to change the e-mail address in the profile settings, the user is now notified that this is not possible.

How to test: 
- Sign in with your gmail account
- try to change the e-mail
- error message appears
- try to change name + keep e-mail unchanged
- change is successful